### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/src/shop/Evaluation.jsx
+++ b/src/shop/Evaluation.jsx
@@ -181,6 +181,13 @@ const Evaluation = () => {
         mainImageInput.current.click();
     }
 
+    const getSafeImageSrc = (src) => {
+        if (typeof src !== "string") return plusImage;
+        if (src.startsWith("blob:")) return src;
+        if (src.startsWith("data:image/")) return src;
+        return plusImage;
+    }
+
     const handleMainImageChange = (event) => {
         const file = event.target.files[0];
         if (!file) return;
@@ -278,7 +285,7 @@ const Evaluation = () => {
                             <img
                                 onClick={() => mainImageClick()}
                                 className="border border-secondary border-2 rounded-4"
-                                src={mainImage}
+                                src={getSafeImageSrc(mainImage)}
                                 alt="image"
                                 width={210}
                                 height={210} />


### PR DESCRIPTION
Potential fix for [https://github.com/Henlla/vintagewatchapp/security/code-scanning/2](https://github.com/Henlla/vintagewatchapp/security/code-scanning/2)

General fix: only render trusted/safe URL forms into DOM URL attributes and gate untrusted file data with strict validation before creating/using object URLs.

Best fix in this file:
1. Add a small helper in `src/shop/Evaluation.jsx` to allow only `blob:` (and optionally `data:image/`) URLs for image `src`.
2. Use that helper when rendering `<img src=...>` so untrusted strings never flow directly into the sink.
3. Keep existing UX/behavior by falling back to `plusImage` if URL is not allowed.
4. (Optional but useful for analyzers) keep current MIME checks and ensure `mainImage` is only set from validated file flow.

Changes needed:
- In `src/shop/Evaluation.jsx`, add `getSafeImageSrc` helper near other handlers.
- Replace line 281 `src={mainImage}` with `src={getSafeImageSrc(mainImage)}`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
